### PR TITLE
fix(build): import Application and not App from @feathersjs/feathers

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,10 +1,10 @@
-import { App } from '@feathersjs/feathers';
+import { Application } from '@feathersjs/feathers';
 import merge from 'deepmerge';
 
 import { AgendaService } from '.';
 import { FeathersAgendaOptions } from './types';
 
-export async function setup(app: App, options?: FeathersAgendaOptions) {
+export async function setup(app: Application, options?: FeathersAgendaOptions) {
   const defaults: FeathersAgendaOptions = {
     agendaConfig: {
       db: {


### PR DESCRIPTION
First of all thanks for the package @bitflower !

When building my application, I encountered the following error: `"Build": node_modules/feathers-agenda/dist/index.d.ts(6,31): error TS2305: Module '"`

This is because `@feathersjs/feathers` exports `Application`, not `App`. 

Note this only happens after the build (when generating `feathers-agenda/dist/index.d.t`), locally it works just fine.

It is a small fix indeed, I hope you can release this soon.

Thanks!